### PR TITLE
Add Bottom layers option

### DIFF
--- a/src/libslic3r/Format/GOO.cpp
+++ b/src/libslic3r/Format/GOO.cpp
@@ -38,6 +38,20 @@ static float constrained_map(float value, float min, float max, float out_min, f
     return out_min * (1 - t) + out_max * t;
 }
 
+static float generate_layer_exposure_time(
+    int current_layer, int bottom_layers, int faded_layers,
+    float initial_exposure_time, float exposure_time
+) {
+    if (current_layer <= bottom_layers) {
+        return initial_exposure_time;
+    } else {
+        return constrained_map(
+            current_layer - bottom_layers, 1, faded_layers + 1,
+            initial_exposure_time, exposure_time
+        );
+    }
+}
+
 static void write_thumbnail(
     size_t width, size_t height, const ThumbnailsList &thumbnails, uint16_t *buffer
 ) {
@@ -375,8 +389,8 @@ void GOOWriter::export_print(
         l_def.position_mm = hton<float>(
             mat.initial_layer_height.getFloat() + layer_height * (current_layer - 1)
         );
-        l_def.exposure_time_s = hton(constrained_map(
-            current_layer, 1, obj_stats.faded_layers + 1, //
+        l_def.exposure_time_s = hton(generate_layer_exposure_time(
+            current_layer, obj_stats.bottom_layers, obj_stats.faded_layers,
             mat.initial_exposure_time, mat.exposure_time
         ));
         l_def.off_time_s = 0;

--- a/src/libslic3r/Format/GOO.cpp
+++ b/src/libslic3r/Format/GOO.cpp
@@ -331,7 +331,7 @@ void GOOWriter::export_print(
     h_info.after_lift_time_s = hton(option_as_float(mat.sla_wait_after_lift));
     h_info.after_retract_time_s = hton(option_as_float(mat.sla_wait_after_retract));
     h_info.bottom_exposure_time_s = hton(option_as_float(mat.initial_exposure_time));
-    h_info.bottom_layers = hton<uint32_t>(obj_stats.faded_layers + 1), // NOTE: Faded layers + initial layer have increased exposure
+    h_info.bottom_layers = hton<uint32_t>(obj_stats.bottom_layers),
     h_info.bottom_lift_distance_mm = hton(option_as_float(mat.sla_initial_primary_lift_distance));
     h_info.bottom_lift_speed_mm_min = hton(option_as_float(mat.sla_initial_primary_lift_speed));
     h_info.lift_distance_mm = hton(option_as_float(mat.sla_primary_lift_distance));

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -540,6 +540,7 @@ static std::vector<std::string> s_Preset_printer_options {
 static std::vector<std::string> s_Preset_sla_print_options {
     "layer_height",
     "faded_layers",
+    "bottom_layers",
     "supports_enable",
     "support_tree_type",
 

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4183,6 +4183,14 @@ void PrintConfigDef::init_sla_params()
     def->mode = comExpert;
     def->set_default_value(new ConfigOptionInt(10));
 
+    def = this->add("bottom_layers", coInt);
+    def->label = L("Bottom Layers");
+    def->tooltip = L("Number of layers the initial exposure time is repeated for.");
+    def->min = 1;
+    def->max = 20;
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionInt(10));
+
     def = this->add("min_exposure_time", coFloat);
     def->label = L("Minimum exposure time");
     def->tooltip = L("Minimum exposure time");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4189,7 +4189,7 @@ void PrintConfigDef::init_sla_params()
     def->min = 1;
     def->max = 20;
     def->mode = comExpert;
-    def->set_default_value(new ConfigOptionInt(10));
+    def->set_default_value(new ConfigOptionInt(2));
 
     def = this->add("min_exposure_time", coFloat);
     def->label = L("Minimum exposure time");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -988,7 +988,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     //Number of the layers needed for the exposure time fade [3;20]
     ((ConfigOptionInt,  faded_layers))/*= 10*/
     //Number of layers the initial exposure time is repeated for [1;20]
-    ((ConfigOptionInt,  bottom_layers))/*= 10*/
+    ((ConfigOptionInt,  bottom_layers))/*= 2*/
 
     ((ConfigOptionFloat, slice_closing_radius))
     ((ConfigOptionEnum<SlicingMode>, slicing_mode))

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -987,6 +987,8 @@ PRINT_CONFIG_CLASS_DEFINE(
 
     //Number of the layers needed for the exposure time fade [3;20]
     ((ConfigOptionInt,  faded_layers))/*= 10*/
+    //Number of layers the initial exposure time is repeated for [1;20]
+    ((ConfigOptionInt,  bottom_layers))/*= 10*/
 
     ((ConfigOptionFloat, slice_closing_radius))
     ((ConfigOptionEnum<SlicingMode>, slicing_mode))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -5878,6 +5878,7 @@ void TabSLAPrint::build()
     auto optgroup = page->new_optgroup(L("Layers"));
     optgroup->append_single_option_line("layer_height");
     optgroup->append_single_option_line("faded_layers");
+    optgroup->append_single_option_line("bottom_layers");
 
     page = add_options_page(L("Supports"), "support"/*"sla_supports"*/);
 


### PR DESCRIPTION
This pull request resolves issue #2 by adding a new "Bottom layers" option to Prusa Slicer's SLA support to better reflect the underlying structure of the .GOO file format. This is implemented by both setting `header_info::bottom_layers` to the user-supplied value and setting the exposure values in the `layer_definition` structures to the bottom exposure value.

I have tested this and it produces well-formed .GOO files with the correct values. It does **not** fix the issue with failing prints when `header_info::advance_mode_layer_definition` is enabled on Saturn printers for reasons that are not yet clear.

Possible things you might want to review:

- I repeat the bottom exposure value for N layers and then start the lerp between bottom exposure and standard exposure on the next layer, with `t = 0`. This technically results in N + 1 layers with bottom exposure time and I am unsure if this is correct or not.
- The default values might be undesirable. The combination of this being an expert-level setting with a default value of 2 might lead to Saturn settings being used on Mars printers by inexperienced users and I am unsure what the result of that would be.