### PR TITLE
Add GOO advanced mode option

### DIFF
--- a/src/libslic3r/Format/GOO.cpp
+++ b/src/libslic3r/Format/GOO.cpp
@@ -350,7 +350,7 @@ void GOOWriter::export_print(
     h_info.second_retract_speed_mm_min = hton(option_as_float(mat.sla_secondary_retract_speed));
     h_info.bottom_light_pwm = hton(option_as_uint16(mat.initial_exposure_pwm));
     h_info.light_pwm = hton(option_as_uint16(mat.exposure_pwm));
-    h_info.advance_mode_layer_definition = true;
+    h_info.advance_mode_layer_definition = m_cfg.goo_advanced_mode;
     h_info.printing_time_s = hton<uint32_t>(stats.estimated_print_time);
     h_info.total_volume_mm3 = hton<float>(stats.total_weight / mat.material_density.getFloat());
     h_info.total_weight_g = hton<float>(stats.total_weight);

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -713,6 +713,7 @@ static std::vector<std::string> s_Preset_sla_printer_options {
     "time_estimate_correction",
     "min_exposure_time", "max_exposure_time",
     "min_initial_exposure_time", "max_initial_exposure_time", "sla_archive_format", "sla_output_precision",
+    "goo_advanced_mode",
     //FIXME the print host keys are left here just for conversion from the Printer preset to Physical Printer preset.
     "print_host", "printhost_apikey", "printhost_cafile",
     "printer_notes",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4712,6 +4712,16 @@ void PrintConfigDef::init_sla_params()
     def->mode = comExpert;
     def->set_default_value(new ConfigOptionFloat(0.001));
 
+    def = this->add("goo_advanced_mode", coBool);
+    def->label = L("GOO advanced mode");
+    def->tooltip = L(
+        "Advanced mode in GOO files allows the slicer to specify exact per-layer print settings. When disabled "
+        "the printer will compute per-layer settings from the general print settings. Advanced mode must be "
+        "disabled when exporting files for use with ELEGOO Saturn printers."
+    );
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionBool(true));
+
     // Declare retract values for material profile, overriding the print and printer profiles.
     for (const char* opt_key : {
         // float

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1296,6 +1296,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                      max_initial_exposure_time))
     ((ConfigOptionString,                     sla_archive_format))
     ((ConfigOptionFloat,                      sla_output_precision))
+    ((ConfigOptionBool,                       goo_advanced_mode))
     ((ConfigOptionString,                     printer_model))
 )
 

--- a/src/libslic3r/SLAPrint.cpp
+++ b/src/libslic3r/SLAPrint.cpp
@@ -864,6 +864,7 @@ bool SLAPrint::invalidate_state_by_config_options(const std::vector<t_config_opt
         "display_orientation"sv,
         "sla_archive_format"sv,
         "sla_output_precision"sv,
+        "goo_advanced_mode"sv,
         // tilt params
         "delay_before_exposure"sv,
         "delay_after_exposure"sv,

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3001,6 +3001,7 @@ void TabPrinter::build_sla()
     optgroup = page->new_optgroup(L("Output"));
     optgroup->append_single_option_line("sla_archive_format");
     optgroup->append_single_option_line("sla_output_precision");
+    optgroup->append_single_option_line("goo_advanced_mode");
 
     build_print_host_upload_group(page.get());
 


### PR DESCRIPTION
In the absence of any more thorough solutions for creating files compatible with ELEGOO Saturn printers I have added a new printer output option, GOO advanced mode, which directly toggles the `advance_mode_layer_definition` flag in the GOO file format.

I'm just creating this pull request to bring this feature to your attention: it's entirely up to you whether you want to merge this or not. On the one hand it _is_ a somewhat ugly GOO-specific hack (if you know how to toggle the field's visibility based on the output format selected please let me know and I will be happy to add it) but on the other it does fix compatibility with Saturn printers which otherwise will likely to be broken (in a way that is mildly damaging to unsuspecting user's hardware) for the foreseeable future.

I have also contacted ELEGOO to ask them if there's any undocumented behavior of the `advance_mode_layer_definition` flag that might be causing the need for this and I'll let you know if I hear back.